### PR TITLE
Bumped to V5

### DIFF
--- a/Move.toml
+++ b/Move.toml
@@ -2,7 +2,7 @@
 name = "EmberVaults"
 version = "1.0.0"
 edition = "2024.beta"
-published-at = "0x3635933713dc35fe5e34f598b32a9d78c3b68faeb8dc5a842c5c6e5d549f56d4"
+published-at = "0x4e1634d0001f22e24ca9fe2127aa49461ea3c320d4456c005b2ad86038b3f863"
 
 [addresses]
 ember_vaults = "0xc83d5406fd355f34d3ce87b35ab2c0b099af9d309ba96c17e40309502a49976f"


### PR DESCRIPTION
Updated `published-at` package id to the latest, version 5 package.